### PR TITLE
version 0.5.2: more reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blitz-replays"
-version = "0.5.1"
+version = "0.5.2"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Tool to upload and analyze Wargaming's World of Tanks Blitz game repolays"
 readme = "README.md"

--- a/src/blitzreplays/replays/analyze.py
+++ b/src/blitzreplays/replays/analyze.py
@@ -442,20 +442,24 @@ async def replay_read_worker(
                     )
                     stats.log("conversion errors")
                     raise ValueError()
+            else:
+                verbose(f"could not read replay: {fn.name}")
+                stats.log("errors")
+                continue
         except Exception as err:
             error(f"could not read replay: {fn}: {type(err)}: {err}")
             stats.log("errors")
             continue
         try:
-            if replay is not None:
+            if replay.is_complete:
                 await replay.enrich(tankopedia=tankopedia, maps=maps, player=player)
                 await stats_cache.queue_stats(
                     replay, accountQ=accountQ, query_cache=query_cache
                 )
                 await replayQ.put(replay)
             else:
-                stats.log("errors")
-                raise ValueError()
+                verbose(f"replay is incomplete: {replay.title}")
+                stats.log("incomplete")
         except Exception as err:
             error(f"could not enrich replay: {fn}: {type(err)}: {err}")
             stats.log("processing errors")

--- a/src/blitzreplays/replays/analyze.py
+++ b/src/blitzreplays/replays/analyze.py
@@ -216,7 +216,7 @@ def analyze(
         debug("Reports EOF -----------------------------------------------------")
 
     except Exception as err:
-        error(f"could not parse analyze TOML config file {err}")
+        error(f"could not parse analyze TOML config file: {type(err)} {err}")
         typer.Exit(code=2)
 
 

--- a/src/blitzreplays/replays/analyze.py
+++ b/src/blitzreplays/replays/analyze.py
@@ -122,6 +122,7 @@ def analyze(
                 )
         debug("--stats-type=%s", stats_type_param.value)
         ctx.obj["stats_type"] = stats_type_param.value
+        # TODO: merge / update user config file with defaults
         if analyze_config_fn is None:
             def_config: Traversable = importlib.resources.files(
                 "blitzreplays.replays"

--- a/src/blitzreplays/replays/cache.py
+++ b/src/blitzreplays/replays/cache.py
@@ -260,6 +260,12 @@ class APICache(ABC):
 
 
 class PlayertatsAPICache(APICache):
+    """
+    Cache player stats into memory or database backend for better search performance
+    """
+
+    # TODO: add database cache
+
     def __init__(self: Self, wg_api: WGApi):
         super().__init__(wg_api)
 
@@ -270,7 +276,7 @@ class PlayertatsAPICache(APICache):
         """
         async worker to fetch stats from WG API
         """
-        # TODO: add database cache
+
         stats = EventCounter("WG API")
         regionQ: Dict[Region, Set[AccountId]] = dict()
         # res: Dict[str, PlayerStats]
@@ -390,8 +396,10 @@ class PlayertatsAPICache(APICache):
 
 class TankStatsAPICache(APICache):
     """
-    Helper class to store tank stats in a dict vs list for search performance
+    Cache tank stats into memory or database backend for better search performance
     """
+
+    # TODO: add database cache
 
     def __init__(self: Self, wg_api: WGApi, tankopedia: WGApiWoTBlitzTankopedia):
         super().__init__(wg_api)

--- a/src/blitzreplays/replays/config.toml
+++ b/src/blitzreplays/replays/config.toml
@@ -102,7 +102,7 @@ format = ".0f"
 
 [REPORTS]
 default = ["total", "battle_result", "tank_tier", "mastery_badge"]
-extra = ["is_premium", "battle_tier"]
+extra = ["is_premium", "battle_tier", "map"]
 
 
 [REPORT.total]
@@ -137,3 +137,8 @@ categories = ["Tech tree", "Premium"]
 name = "Battle tier"
 categorization = "number"
 field = "battle_tier"
+
+[REPORT.map]
+name = "Map"
+categorization = "string"
+field = "map"

--- a/src/blitzreplays/replays/config.toml
+++ b/src/blitzreplays/replays/config.toml
@@ -124,5 +124,5 @@ categories = ["-", "3rd Class", "2nd Class", "1st Class", "Mastery"]
 [REPORT.is_premium]
 name = "Tank type"
 categorization = "category"
-field = "player.tank.is_premium"
+field = "player.tank_is_premium"
 categories = ["Tech tree", "Premium"]

--- a/src/blitzreplays/replays/config.toml
+++ b/src/blitzreplays/replays/config.toml
@@ -101,7 +101,7 @@ format = ".0f"
 
 
 [REPORTS]
-default = ["total", "battle_result", "tank_tier", "mastery_badge"]
+default = ["total", "battle_result", "tank_tier", "mastery_badge", "avg_dmg"]
 extra = ["is_premium", "battle_tier", "map"]
 
 
@@ -142,3 +142,19 @@ field = "battle_tier"
 name = "Map"
 categorization = "string"
 field = "map"
+
+[REPORT.avg_dmg]
+name = "Average dmg"
+categorization = "bucket"
+field = "player.damage_made"
+buckets = [0, 1000, 1500, 2000, 2500, 3000, 4000, 5000]
+bucket_labels = [
+    "0 - 1000",
+    "1000 - 1500",
+    "1500 - 2000",
+    "2000 - 2500",
+    "2500 - 3000",
+    "3000 - 4000",
+    "4000 - 5000",
+    "5000+",
+]

--- a/src/blitzreplays/replays/config.toml
+++ b/src/blitzreplays/replays/config.toml
@@ -101,8 +101,8 @@ format = ".0f"
 
 
 [REPORTS]
-default = ["total", "battle_result", "mastery_badge"]
-extra = ["is_premium"]
+default = ["total", "battle_result", "tank_tier", "mastery_badge"]
+extra = ["is_premium", "battle_tier"]
 
 
 [REPORT.total]
@@ -115,6 +115,12 @@ categorization = "category"
 field = "battle_result"
 categories = ["Loss", "Win", "Draw"]
 
+[REPORT.tank_tier]
+name = "Tank tier"
+categorization = "category"
+field = "player.tank_tier"
+categories = ["-", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+
 [REPORT.mastery_badge]
 name = "Mastery"
 categorization = "category"
@@ -126,3 +132,8 @@ name = "Tank type"
 categorization = "category"
 field = "player.tank_is_premium"
 categories = ["Tech tree", "Premium"]
+
+[REPORT.battle_tier]
+name = "Battle tier"
+categorization = "number"
+field = "battle_tier"

--- a/src/blitzreplays/replays/config.toml
+++ b/src/blitzreplays/replays/config.toml
@@ -14,7 +14,7 @@ format = "d"
 name = "WR"
 metric = "average_if"
 fields = "battle_result=1"
-format = ".2%"
+format = ".1%"
 
 [[FIELDS.default]]
 name = "DPB"

--- a/src/blitzreplays/replays/models_replay.py
+++ b/src/blitzreplays/replays/models_replay.py
@@ -259,12 +259,20 @@ class EnrichedReplay(Replay):
         """
 
         data: EnrichedPlayerData
+        if not self.is_complete:
+            raise ValueError(f"replay is incomplete: {self.title}")
+
         # add tanks
         for data in self.players_dict.values():
             tank_id: TankId = data.vehicle_descr
             try:
                 tank: Tank = tankopedia[tank_id]
-                data.tank = tank
+                data.tank = tank.name
+                data.tank_id = tank.tank_id
+                data.tank_type = tank.type.name  # type: ignore
+                data.tank_tier = tank.tier.value
+                data.tank_is_premium = tank.is_premium
+
                 self.battle_tier = max(self.battle_tier, int(tank.tier))
             except KeyError:
                 debug("could not find tank_id=%d from Tankopedia", tank_id)

--- a/src/blitzreplays/replays/models_replay.py
+++ b/src/blitzreplays/replays/models_replay.py
@@ -14,7 +14,6 @@ from blitzmodels import (
     AccountId,
     EnumVehicleTypeStr,
     Maps,
-    Map,
     Tank,
     TankStat,
     TankId,
@@ -230,7 +229,7 @@ class EnrichedReplay(Replay):
     player: AccountId = -1
     plat_mate: List[AccountId] = Field(default_factory=list)
     battle_tier: int = 0
-    map: Map | None = None
+    map: str = "-"
     top_tier: bool = False
 
     model_config = ConfigDict(
@@ -314,7 +313,7 @@ class EnrichedReplay(Replay):
             self.allies.remove(self.plat_mate[0])
 
         try:
-            self.map = maps[self.map_id]
+            self.map = maps[self.map_id].name
         except (KeyError, ValueError):
             error(f"no map (id={self.map_id}) in Maps file")
 

--- a/src/blitzreplays/replays/models_reports.py
+++ b/src/blitzreplays/replays/models_reports.py
@@ -622,10 +622,13 @@ class Categorization(ABC):
 
     categorization: ClassVar[str] = "<NOT DEFINED>"
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, field: str):
         self.name: str = name
         # self._battles: int = 0
-        # self._field: str = field
+        is_player_field: bool
+        field, is_player_field = self.parse_field(field)
+        self._field: str = field
+        self._is_player_field: bool = is_player_field
         self._categories: Dict[CategoryKey, Category] = defaultdict(default_Category)
 
     @property
@@ -664,6 +667,42 @@ class Categorization(ABC):
                 error("category=%s: %s: %s", cat_key, type(err), str(err))
         debug("data=%s", str(data))
         print(tabulate(data, headers=header))
+
+    def parse_field(self, field: str) -> Tuple[str, bool]:
+        """parse field and check is it a player field"""
+        if field.startswith("player."):
+            return field.removeprefix("player."), True
+        else:
+            return field, False
+
+    @property
+    def category_field(self) -> str:
+        """return full category field"""
+        if self._is_player_field:
+            return "player." + self._field
+        else:
+            return self._field
+
+    def get_category_int(self, replay: EnrichedReplay) -> int:
+        """Return integer field value"""
+        if self._is_player_field:
+            return int(getattr(replay.players_dict[replay.player], self._field))
+        else:
+            return int(getattr(replay, self._field))
+
+    def get_category_float(self, replay: EnrichedReplay) -> float:
+        """Get category field's value as float for the replay"""
+        if self._is_player_field:
+            return float(getattr(replay.players_dict[replay.player], self._field))
+        else:
+            return float(getattr(replay, self._field))
+
+    def get_category_str(self, replay: EnrichedReplay) -> str:
+        """Get category field's value as str for the replay"""
+        if self._is_player_field:
+            return str(getattr(replay.players_dict[replay.player], self._field))
+        else:
+            return str(getattr(replay, self._field))
 
 
 class Reports:

--- a/src/blitzreplays/replays/models_reports.py
+++ b/src/blitzreplays/replays/models_reports.py
@@ -859,6 +859,20 @@ class StrCategorization(Categorization):
 
     categorization = "string"
 
+    def get_category(self, replay: EnrichedReplay) -> Category | None:
+        try:
+            return self._categories[self.get_category_str(replay)]
+        except AttributeError as err:
+            error(
+                f"field={self.category_field} not found in replay: {replay.title}: {err}"
+            )
+        except KeyError as err:
+            error(f"{type(err)}: {err}")
+        return None
+
+
+Reports.register(StrCategorization)
+
 
 # TODO: BucketCategorization
 class BucketCategorization(Categorization):

--- a/src/blitzreplays/replays/models_reports.py
+++ b/src/blitzreplays/replays/models_reports.py
@@ -789,15 +789,14 @@ class ClassCategorization(Categorization):
     categorization = "category"
 
     def __init__(self, name: str, field: str, categories: List[str]):
-        super().__init__(name=name)
-        self._field: str = field
+        super().__init__(name=name, field=field)
         self._category_cache: Dict[int, str] = dict()
         for ndx, cat in enumerate(categories):
-            self._category_cache[ndx] = cat
+            self._category_cache[int(ndx)] = cat
 
     def get_category(self, replay: EnrichedReplay) -> Category | None:
         try:
-            field_value: int = getattr(replay, self._field)
+            field_value: int = self.get_category_int(replay)
             category: CategoryKey = self._category_cache[field_value]
             return self._categories[category]
         except AttributeError:
@@ -805,6 +804,15 @@ class ClassCategorization(Categorization):
         except KeyError as err:
             error(err)
         return None
+
+    @property
+    def categories(self) -> List[CategoryKey]:
+        """Get category keys in in order specified"""
+        return [
+            cat
+            for cat in self._category_cache.values().__reversed__()
+            if cat in self._categories
+        ]
 
 
 Reports.register(ClassCategorization)

--- a/src/blitzreplays/replays/models_reports.py
+++ b/src/blitzreplays/replays/models_reports.py
@@ -767,7 +767,7 @@ class Totals(Categorization):
     categorization = "total"
 
     def __init__(self, name: str):
-        super().__init__(name="Total")
+        super().__init__(name="Total", field="exp")
         self._categories["Total"] = Category()
 
     def get_category(self, replay: EnrichedReplay) -> Category | None:
@@ -818,8 +818,8 @@ class ClassCategorization(Categorization):
 Reports.register(ClassCategorization)
 
 
-# TODO: IntCategorization
-class IntCategorization(Categorization):
+# TODO: NumberCategorization
+class NumberCategorization(Categorization):
     """
     "protagonist": ["account_id", "number"],
     "battle_i": ["Battle #", "number"],
@@ -829,6 +829,23 @@ class IntCategorization(Categorization):
     """
 
     categorization = "number"
+
+    # def __init__(self, name: str, field: str, categories: List[str]):
+    #     super().__init__(name=name, field=field)
+
+    def get_category(self, replay: EnrichedReplay) -> Category | None:
+        try:
+            return self._categories[self.get_category_str(replay)]
+        except AttributeError as err:
+            error(
+                f"field={self.category_field} not found in replay: {replay.title}: {err}"
+            )
+        except KeyError as err:
+            error(f"{type(err)}: {err}")
+        return None
+
+
+Reports.register(NumberCategorization)
 
 
 # TODO: StrCategorization

--- a/src/blitzreplays/replays/models_reports.py
+++ b/src/blitzreplays/replays/models_reports.py
@@ -771,7 +771,8 @@ class ClassCategorization(Categorization):
 Reports.register(ClassCategorization)
 
 
-class NumberCategorization(Categorization):
+# TODO: IntCategorization
+class IntCategorization(Categorization):
     """
     "protagonist": ["account_id", "number"],
     "battle_i": ["Battle #", "number"],
@@ -783,6 +784,7 @@ class NumberCategorization(Categorization):
     categorization = "number"
 
 
+# TODO: StrCategorization
 class StrCategorization(Categorization):
     """
     "player_name": ["Player", "string", 25],
@@ -794,6 +796,7 @@ class StrCategorization(Categorization):
     categorization = "string"
 
 
+# TODO: BucketCategorization
 class BucketCategorization(Categorization):
     """
     "allies_battles": [

--- a/src/blitzreplays/replays/models_reports.py
+++ b/src/blitzreplays/replays/models_reports.py
@@ -722,12 +722,15 @@ class Reports:
         try:
             cat: Type[Categorization] = self._db[categorization]
             if key in self._reports:
-                raise KeyError(f"duplicate definition of report='{key}'")
+                raise ValueError(f"duplicate definition of report='{key}'")
             self._reports[key] = cat(name=name, **kwargs)
         except KeyError as err:
             error(
                 f"could not create report: key={key}, name={name}, categorization={categorization}, {', '.join('='.join([k,v]) for k,v in kwargs.items())}"
             )
+            error(err)
+            raise
+        except ValueError as err:
             error(err)
             raise
         except Exception as err:
@@ -829,9 +832,6 @@ class NumberCategorization(Categorization):
     """
 
     categorization = "number"
-
-    # def __init__(self, name: str, field: str, categories: List[str]):
-    #     super().__init__(name=name, field=field)
 
     def get_category(self, replay: EnrichedReplay) -> Category | None:
         try:

--- a/tests/test_blitzreplays.py
+++ b/tests/test_blitzreplays.py
@@ -160,7 +160,17 @@ def test_2_blitzreplays_analyze_files(
         (["--fields", "+extra", "files"]),
         (["--player", "521458531", "files"]),
         (["--reports", "extra", "files"]),
-        (["--reports", "+extra", "files", "--wg-rate-limit", "10"]),
+        (
+            [
+                "--reports",
+                "+extra",
+                "--fields",
+                "+extra",
+                "files",
+                "--wg-rate-limit",
+                "10",
+            ]
+        ),
     ],
 )
 @REPLAY_ANALYZE_FILES


### PR DESCRIPTION
## Fixes

- Skip incomplete replays
- Better error messages

## All categorizations implemented 🎉 

- Now all basic reports (`categorization` param under TOML `REPORT.report_name`) are implemented:

###  `categorization = "total"`

- Overall stats i.e. single categorization that matches all the replays

```
[REPORT.total]
name = "All battles"
categorization = "total"
```


###  `categorization = "category"`

- Uses categorization field's integer value to map it to a category defined as an TOML array.

```
[REPORT.battle_result]
name = "Battle result"
categorization = "category"
field = "battle_result"
categories = ["Loss", "Win", "Draw"]
```

###  `categorization = "number"`

- Uses categorization field's integer value as category id.

```
[REPORT.battle_tier]
name = "Battle tier"
categorization = "number"
field = "battle_tier"
```

### `categorization = "string"`

- Uses a replay field's `string` value as a category key

```
[REPORT.map]
name = "Map"
categorization = "string"
field = "map"
```

###  `categorization = "bucket"`

- Maps a replay to a "bucket" based on fields numerical value. The buckets are defined with by their lower bounds. 

```
[REPORT.avg_dmg]
name = "Average dmg"
categorization = "bucket"
field = "player.damage_made"
buckets = [0, 1000, 1500, 2000, 2500, 3000, 4000, 5000]
bucket_labels = [
    "0 - 1000",
    "1000 - 1500",
    "1500 - 2000",
    "2000 - 2500",
    "2500 - 3000",
    "3000 - 4000",
    "4000 - 5000",
    "5000+",
]
```